### PR TITLE
Add RELMO to general_info and 2011 is no longer recent

### DIFF
--- a/elmo/static/general_info.html
+++ b/elmo/static/general_info.html
@@ -20,5 +20,5 @@ The <b>ELSMO</b> is an addition to the ELMO given to the misguided souls who unf
 The name and appearance of the ELSMO also differ from the corresponding ELMO, typically with rather questionable design choices.
 
 Conversely, the Revenge ELMO, or <b>RELMO</b> and (sometimes the corresponding <b>RELSMO</b>) is a new recent addition to the ELMO series,
-ran mainly by MOP first years and sometimes disgruntled others, to act as a "revenge" against the directors and authors responsible for ELMO.
-These problems possess a special quality, namely being either antiproblems or exceptionally hard in nature.
+run mainly by MOP first years and sometimes disgruntled others, to act as a "revenge" against the directors and authors responsible for ELMO.
+These problems possess a special quality.

--- a/elmo/static/general_info.html
+++ b/elmo/static/general_info.html
@@ -1,5 +1,5 @@
 <h2>General Information</h2>
-The name of the <b>ELMO</b> changes each year.  Here are some more recent names:
+The name of the <b>ELMO</b> changes each year.  Here are some example names:
 <ul>
 <li>Ego Loss May Occur</li>
 <li>Everybody Lives at Most Once</li>
@@ -16,6 +16,9 @@ The name of the <b>ELMO</b> changes each year.  Here are some more recent names:
 <li>Exceedingly Loquacious Math Olympiad</li>
 </ul>
 
-The <b>ELSMO</b> is a new recent addition to the ELMO given to the misguided souls who unfortunately pronounce MOP as "MOSP", with an additional "S".
-The ELSMO contestants are given three additional problems each day, which are usually ignored by most contestants.
-The name and appearance of the ELSMO also differ from the corresponding ELMO.
+The <b>ELSMO</b> is an addition to the ELMO given to the misguided souls who unfortunately pronounce MOP as "MOSP", with an additional "S".
+The name and appearance of the ELSMO also differ from the corresponding ELMO, typically with rather questionable design choices.
+
+Conversely, the Revenge ELMO, or <b>RELMO</b> and (sometimes the corresponding <b>RELSMO</b>) is a new recent addition to the ELMO series,
+ran mainly by MOP first years and sometimes disgruntled others, to act as a "revenge" against the directors and authors responsible for ELMO.
+These problems possess a special quality, namely being either antiproblems or exceptionally hard in nature.


### PR DESCRIPTION
Adds RELMO to general info, and rewords some outdated text.

Feel free to reword anything or update anything that is not correct (am not a MOPper).

Not going to include PRELMO since there's a chance that is only a one year thing :p (see https://drive.google.com/file/d/1RnWmYpzFJsY-F2dsmKu9JRAox0QLkocj/view?pli=1).