### PR TITLE
feat(faq-school): fix link to L-14

### DIFF
--- a/input/faq-school.md
+++ b/input/faq-school.md
@@ -26,7 +26,7 @@ See also [S-6](#S-6) below.
 
 ### {{ faq("S-3", "How do you live-TeX your notes so quickly?") }}
 
-See [FAQ L-14](faq-latex.html#L-11).
+See [FAQ L-14](faq-latex.html#L-14).
 
 ### {{ faq("S-4", "How did you take undergraduate / graduate math classes in high school?") }}
 


### PR DESCRIPTION
The link to FAQ L-14 pointed to FAQ L-11 instead.