### PR TITLE
fix: wrong links in faq-linux.md

### DIFF
--- a/input/faq-linux.md
+++ b/input/faq-linux.md
@@ -148,7 +148,7 @@ Also, Fish autocomplete is life-changing 🐟 ❤️ 🔥
 Pretty similar to reasons I use Linux.
 
 - It is extremely customizable, both by
-  [text](https://github.com/vEnhance/dotfiles/blob/main/vimrc),
+  [text](https://github.com/vEnhance/dotfiles/blob/main/vim/vimrc),
   and by a gazillion plugins (also via text)
   for IDE-like features and autocomplete and so on.
 - Any Linux computer will have it.
@@ -156,7 +156,7 @@ Pretty similar to reasons I use Linux.
 - It is programmable. If you want to, say,
   toggle the case of the first character of the next 100 lines,
   you type `qa~j^q99@a`. You don't need any external program.
-- Most importantly, it is a [modal editor](https://en.wikipedia.org/wiki/Vi#Interface).
+- Most importantly, it is a [modal editor](https://en.wikipedia.org/wiki/Vi_(text_editor)#Interface).
 
 The last item is the most important one for me,
 and also the one that will be most foreign to newcomers.

--- a/input/faq-linux.md
+++ b/input/faq-linux.md
@@ -156,7 +156,7 @@ Pretty similar to reasons I use Linux.
 - It is programmable. If you want to, say,
   toggle the case of the first character of the next 100 lines,
   you type `qa~j^q99@a`. You don't need any external program.
-- Most importantly, it is a [modal editor](https://en.wikipedia.org/wiki/Vi_(text_editor)#Interface).
+- Most importantly, it is a [modal editor](<https://en.wikipedia.org/wiki/Vi_(text_editor)#Interface>).
 
 The last item is the most important one for me,
 and also the one that will be most foreign to newcomers.


### PR DESCRIPTION
Vi link led to a disambiguation page
vimrc link led to a 404 page